### PR TITLE
Downloading `libgoast-amd64.so`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,6 +85,10 @@ jobs:
         with:
           name: libgoast-amd64.dylib
           path: .
+      - uses: actions/download-artifact@v4
+        with:
+          name: libgoast-amd64.so
+          path: .
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
We forgot to download `libgoast-amd64.so` for the publish.