### PR TITLE
Bump Go version 1.26

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module cpg
 
-go 1.20
+go 1.26
 
 require (
 	github.com/mattn/go-pointer v0.0.1


### PR DESCRIPTION
Update Go Version to 1.26 to support newest language features.