### PR TITLE
Removing targets, for runners where they are not needed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,8 +68,6 @@ jobs:
       - name: Setup Rust
         if: matrix.project.name == 'rust'
         uses: dtolnay/rust-toolchain@stable
-        with:
-          target: x86_64-apple-darwin,aarch64-apple-darwin
 
       - name: Build
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,11 +45,6 @@ jobs:
             ext: dylib
 
           - arch: amd64
-            os: macos
-            runs-on: macos-latest
-            ext: dylib
-
-          - arch: amd64
             os: windows
             runs-on: windows-latest
             ext: dll
@@ -68,6 +63,8 @@ jobs:
       - name: Setup Rust
         if: matrix.project.name == 'rust'
         uses: dtolnay/rust-toolchain@stable
+        with:
+          target: x86_64-apple-darwin,aarch64-apple-darwin
 
       - name: Build
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,11 @@ jobs:
             ext: dylib
 
           - arch: amd64
+            os: macos
+            runs-on: macos-latest
+            ext: dylib
+
+          - arch: amd64
             os: windows
             runs-on: windows-latest
             ext: dll

--- a/rustast/build.sh
+++ b/rustast/build.sh
@@ -6,19 +6,12 @@ ARCH=$(uname -m)
 
 echo "Building on $OS for $ARCH"
 
-if [ "$OS" = "darwin" ]; then
-    if [ "$ARCH" = "arm64" ]; then
-        cargo build --release
-        cp target/release/librustast.dylib ./librustast-arm64.dylib
-
-    elif [ "$ARCH" = "x86_64" ]; then
-        cargo build --release
-        cp target/release/librustast.dylib ./librustast-amd64.dylib
-
-    else
-        echo "Unsupported macOS architecture: $ARCH"
-        exit 1
-    fi
+if [ "$OS" = "darwin" ]; then 
+    cargo build --release --target aarch64-apple-darwin
+    cargo build --release --target x86_64-apple-darwin
+    
+    cp target/aarch64-apple-darwin/release/librustast.dylib ./librustast-arm64.dylib 
+    cp target/x86_64-apple-darwin/release/librustast.dylib ./librustast-amd64.dylib
 
 elif [ "$OS" = "linux" ]; then
     if [ "$ARCH" = "aarch64" ]; then

--- a/rustast/build.sh
+++ b/rustast/build.sh
@@ -6,7 +6,9 @@ ARCH=$(uname -m)
 
 echo "Building on $OS for $ARCH"
 
-if [ "$OS" = "darwin" ]; then 
+if [ "$OS" = "darwin" ]; then
+    rustup target add x86_64-apple-darwin
+    
     cargo build --release --target aarch64-apple-darwin
     cargo build --release --target x86_64-apple-darwin
     


### PR DESCRIPTION
The extra target for the mac run is added over rustup